### PR TITLE
Fix error message when no uncovered lines

### DIFF
--- a/autoload/istanbul.vim
+++ b/autoload/istanbul.vim
@@ -159,7 +159,7 @@ function! istanbul#update(jsonpath)
         \ len(uncovered), len(uncovered) == 1 ? modestr[0] : modestr[1],
         \ qfstore, qfprefix, qfprefix)
     else
-      echo printf('No uncovered %s.', modestr)
+      echo printf('No uncovered %s.', modestr[1])
     endif
     echohl None
     let state['visible'] = 1


### PR DESCRIPTION
This was throwing a "using List as String" exception.